### PR TITLE
Keep `package.json` and `yarn.lock` in sync with CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
 - node
 script:
+- yarn check --integrity
 - yarn test


### PR DESCRIPTION
`yarn check`:

> Verifies that versions of the package dependencies in the current project’s
> `package.json` matches that of yarn’s lock file.

https://yarnpkg.com/lang/en/docs/cli/check/

Check this in CI, rather than adding to the `test` script, as it allows someone
to to basic things without `yarn` being a hard requirements. They can still:
- run locally and install deps with `npm`
- make changes and run tests using `npm`, as long as they don't change packages

If they add a package via `npm add`, or `package.json` then this CI check will
flag it.